### PR TITLE
travis passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
-
-
+.coverage
+*.swp
+venv/
+.cache/

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     author='Daniel',
     author_email='',
     url='https://github.com/drazul/universal-deployer',
-    #license='MIT',
+    # license='MIT',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+
+
+version = "0.0.1"
+
+
+def read_file(filename):
+    if os.path.exists(filename):
+        with open(filename) as fd:
+            return fd.read()
+    return ''
+
+
+class PyTest(TestCommand):
+    user_options = [
+        ('pytest-args=', 'a', "Arguments to pass to py.test"),
+    ]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest  # NOQA
+        errno = pytest.main(self.pytest_args or ['--cov-report=term-missing'])
+        sys.exit(errno)
+
+
+setup(
+    name='udeploy',
+    version=version,
+    description="Transforms tests in documentation, and viceversa",
+    long_description=read_file('README.rst'),
+    cmdclass={'test': PyTest},
+    classifiers=[
+        # 'Development Status :: 1 - Planning',
+        # 'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
+        # 'Development Status :: 4 - Beta',
+        # 'Development Status :: 5 - Production/Stable',
+        # 'Development Status :: 6 - Mature',
+        # 'Development Status :: 7 - Inactive',
+        # 'Programming Language :: Python :: 2.7',
+        # 'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        # 'Programming Language :: Python :: Implementation :: PyPy',
+        # 'License :: OSI Approved :: MIT License',
+        'Topic :: System :: Installation/Setup',
+        'Operating System :: OS Independent',
+    ],
+    keywords=(
+        'deployment automatic-deployment iis curator nssm'
+        'windows-service chocolatey universal-deployment liquibase'
+        ),
+    author='Daniel',
+    author_email='',
+    url='https://github.com/drazul/universal-deployer',
+    #license='MIT',
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    zip_safe=False,
+    extras_require={
+    },
+    install_requires=[
+        'pyyaml',
+        'jinja2',
+    ],
+    entry_points={
+        'console_scripts': [
+            'udeploy = udeploy.__main__:main',
+        ],
+    },
+)

--- a/tests/integration/test_utils_process.py
+++ b/tests/integration/test_utils_process.py
@@ -1,11 +1,6 @@
 import unittest
-import os
-import sys
 
-cwd = os.getcwd() + '/udeploy'
-sys.path.insert(0, cwd)
-
-from plugins.utils.process import execute
+from udeploy.plugins.utils.process import execute
 
 
 class TestExecute(unittest.TestCase):

--- a/udeploy/__main__.py
+++ b/udeploy/__main__.py
@@ -1,0 +1,5 @@
+from .universal_deployer import main
+
+
+if __name__ == '__main__':
+    main()

--- a/udeploy/plugins/utils/process.py
+++ b/udeploy/plugins/utils/process.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
 
-from logger import logger
+from udeploy.logger import logger
 
 
 def execute(command, ignore_errors=True):

--- a/udeploy/universal_deployer.py
+++ b/udeploy/universal_deployer.py
@@ -132,8 +132,7 @@ class Deployer:
             self._str2method(app, command)()
 
 
-if __name__ == "__main__":
-
+def main():
     _is_windows = platform.system() is 'Windows'
 
     parser = argparse.ArgumentParser(description='Universal deployer')
@@ -249,3 +248,7 @@ if __name__ == "__main__":
 
     logger.info('{project_name} finished successfully!'.format(
         project_name='universal_deployer'))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Locally you have to run `python setup.py develop` (maybe inside a virtualenv) to work, but now it works without patching the sys path.

In addition, all tests are passing now. You can run them with `python setup.py test` or with `pytest`.
Sadly, I do not know how to install test requirements from setup.py (it always give me a headhache and does not run under travis), so it is required for you to run `pip install -r requirements-dev.txt` before testing.

Now you can register yourself under pypi and run `python setup.py bdist_wheel upload` in order to create the package in pypi.

Finally, the file `requeriments.txt` is deprecated. `python setup.py develop` or `python setup.py install` will do the trick.